### PR TITLE
Add detect-secret baseline file to exclude

### DIFF
--- a/exclude-patterns.txt
+++ b/exclude-patterns.txt
@@ -1,1 +1,2 @@
 package-lock.json
+.secrets.baseline


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/PSD-613

Secret baseline contains lots of hashes that are all false positives